### PR TITLE
don't create a new release plan PR when releasing

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
     types: 
       - labeled
@@ -12,14 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-plan:
+    name: "Check Release Plan"
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.check-release.outputs.command }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: 'main'
+      # This will only cause the `check-plan` job to have a "command" of `release`
+      # when the .release-plan.json file was changed on the last commit.
+      - id: check-release
+        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+
   prepare_release_notes:
     name: Prepare Release Notes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: check-plan
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}
+    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4

--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -13,14 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-plan:
+    name: "Check Release Plan"
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.check-release.outputs.command }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: 'main'
+      # This will only cause the `check-plan` job to have a "command" of `release`
+      # when the .release-plan.json file was changed on the last commit.
+      - id: check-release
+        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+
   prepare_release_notes:
     name: Prepare Release Notes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: check-plan
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}
+    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There was a bit of a race condition where you would get a new PR opened just after you release because release-plan was running at the same time as the publish job.

This PR changes it so that the PR is only created when you haven't update `.release-plan.json` i.e. are not doing a release 👍 