### PR TITLE
Fix checking devDependencies on early projects with mostly empty package.json

### DIFF
--- a/bin/release-plan-setup.js
+++ b/bin/release-plan-setup.js
@@ -62,12 +62,11 @@ async function updatePackageJSON() {
     }
   }
 
+  pkg.devDependencies ||= {};
   pkg.devDependencies['release-plan'] = getDependencyRange(
     pkg.devDependencies['release-plan'],
     RELEASE_PLAN_VERSION
   );
-
-  pkg.devDependencies = pkg.devDependencies || {};
 
   let sortedPkg = sortPackageJson(pkg);
   let updatedContents = JSON.stringify(sortedPkg, null, 2);


### PR DESCRIPTION
Ran in to this while setting up release-plan on a new project:
```
❯ npm init release-plan-setup
Need to install the following packages:
create-release-plan-setup@1.4.0
Ok to proceed? (y) y
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
TypeError: Cannot read properties of undefined (reading 'release-plan')
    at updatePackageJSON (file://🏠/.npm/_npx/3d7cd7a712111503/node_modules/create-release-plan-setup/bin/release-plan-setup.js:66:24)
    at async file://🏠/.npm/_npx/3d7cd7a712111503/node_modules/create-release-plan-setup/bin/release-plan-setup.js:175:13
file://🏠/.npm/_npx/3d7cd7a712111503/node_modules/create-release-plan-setup/bin/release-plan-setup.js:66
    pkg.devDependencies['release-plan'],
                       ^

TypeError: Cannot read properties of undefined (reading 'release-plan')
    at updatePackageJSON (file://🏠/.npm/_npx/3d7cd7a712111503/node_modules/create-release-plan-setup/bin/release-plan-setup.js:66:24)
    at async file://🏠/.npm/_npx/3d7cd7a712111503/node_modules/create-release-plan-setup/bin/release-plan-setup.js:175:13

Node.js v18.19.0
npm ERR! code 1
npm ERR! path <repo>
npm ERR! command failed
npm ERR! command sh -c create-release-plan-setup

npm ERR! A complete log of this run can be found in: 🏠/.npm/_logs/2023-12-11T16_12_56_411Z-debug-0.log

```