### PR TITLE
Add workflow_dispatch to the other workflow

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -1,5 +1,6 @@
 name: Release Plan Review
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
I've found this to be helpful because sometimes the plan-release-template runs at the wrong time as you're initially setting up a repo -- timing issues occur, etc.