### PR TITLE
fix the branch used when a PR is labelled

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -46,9 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         # We need to download lots of history so that
-        # lerna-changelog can discover what's changed since the last release
+        # github-changelog can discover what's changed since the last release
         with:
           fetch-depth: 0
+          ref: '<%= defaultBranch %>'
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
This prevents the release plan from effectively being "rolled back" to the PRs that were merged at the time of the PR was created, making sure to always run against the HEAD of main/master 👍 