### PR TITLE
Show unlabelled

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -64,15 +64,22 @@ jobs:
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
-          set -x
+          set +e
           <% if (pnpm) { %>
-          pnpm release-plan prepare
+          pnpm release-plan prepare 2> >(tee -a stderr.log >&2)
           <% } else { %>
-          npx release-plan prepare
+          npx release-plan prepare 2> >(tee -a stderr.log >&2)
           <% } %>
-          echo 'text<<EOF' >> $GITHUB_OUTPUT
-          jq .description .release-plan.json -r >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+
+          if [ $? -ne 0 ]; then
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+            cat stderr.log >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          else
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+            jq .description .release-plan.json -r >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This is making use of https://github.com/embroider-build/github-changelog/pull/11 and https://github.com/embroider-build/release-plan/pull/56 and making sure that unlabelled PRs actually show up in the PR for Prepare Release