### PR TITLE
Stop creating a "Prepare Release vnull" PR when there is nothing to release

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -47,6 +47,7 @@ jobs:
 
       - uses: peter-evans/create-pull-request@v8
         name: Create Prepare Release PR
+        if: steps.explanation.outputs.new-version != '' && steps.explanation.outputs.new-version != 'vnull'
         with:
           commit-message: "Prepare Release ${{ steps.explanation.outputs.new-version}} using 'release-plan'"
           labels: "internal"


### PR DESCRIPTION
I often end up with a `Prepare Release vnull` PR when setting up release-plan in a new repo, this should guard against that.