### PR TITLE
docs: disallow rebase merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ This is a simple npm init package to add the perfect release-plan setup. Running
 
 ## Usage
 
+### Disallow rebase merging on your repository
+
+Rebase merging produces commits on the main branch that do not include a link to the original PR. When used, `release-plan` will not be able to produce a correct changelog and determine the version bump to perform.
+
+Make sure [rebase merging is disallowed](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-rebasing-for-pull-requests) when using `release-plan`.
+
 ### Generate a GitHub personal access token
 
 1. Obtain a [GitHub personal access token](https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable).
 2. Make sure the token is available locally as the `GITHUB_AUTH` environment variable. (you can also prepend it to the init script)
-  
+
   For instance:
   ```bash
   export GITHUB_AUTH=abc123def456
@@ -58,14 +64,14 @@ As this workflow automatically creates a PR for you during the release process y
 
 ### Set up Trusted Publishing for your package
 
-Once you're ready to do your first release with this release-plan setup your GitHub Actions will 
+Once you're ready to do your first release with this release-plan setup your GitHub Actions will
 need to be authorized to publish your package to npm. To do this, you will set up
 [Trusted Publishing](https://docs.npmjs.com/trusted-publishers#for-github-actions) for your package.
 This is sometimes referred to as 'OIDC'.
 
-If you are creating a new package, you will need to manually publish once first 
-in order to have access to settings to set up Trusted Publishing. 
-Be sure you are okay with the version in `package.json` as the first version then run `npm publish`. 
+If you are creating a new package, you will need to manually publish once first
+in order to have access to settings to set up Trusted Publishing.
+Be sure you are okay with the version in `package.json` as the first version then run `npm publish`.
 
 Now you should be free to merge your PR and release your package with release-plan 🎉
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,8 @@
 
 Releases in this repo are mostly automated using [release-plan](https://github.com/embroider-build/release-plan/). Once you label all your PRs correctly (see below) you will have an automatically generated PR that updates your CHANGELOG.md file and a `.release-plan.json` that is used to prepare the release once the PR is merged.
 
+Make sure you never merge PRs with rebase when using `release-plan`. You can [disallow rebase merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-rebasing-for-pull-requests) in your repository settings.
+
 ## Preparation
 
 Since the majority of the actual release process is automated, the remaining tasks before releasing are:


### PR DESCRIPTION
Rebase merges produce a git history that does not include PR numbers, which makes [`github-changelog` fail to generate a proper changelog](https://github.com/release-plan/github-changelog/blob/main/src/find-pull-request-id.ts).

Doing a merge with rebase on a repository with `release-plan` will produce a `Prepare release vnull` PR with a faulty `.release-plan.json` and empty changelog:

```json
{
  "solution": {
    "@org/package": {
      "oldVersion": "1.2.3"
    }
  },
  "description": "\n\n\n\n"
}
```

This PR updates the README and `RELEASE.md` to suggest disabling rebase merging on their repositories.